### PR TITLE
Added selector tools to use when filtering for nodes.

### DIFF
--- a/src/DocTree.stanza
+++ b/src/DocTree.stanza
@@ -95,6 +95,11 @@ public defn get-children (node?:Maybe<TidyNode>) -> Seq<TidyNode> :
     (x:One<TidyNode>):
       get-children(value(x))
 
+public defn is-tag-id? (node:TidyNode, tagId:TidyTagId) -> True|False :
+  ; This function is used for filtering the children of a
+  ;   node by a particular type.
+  get-id(node) == tagId
+
 public lostanza defn get-next (node:ref<TidyNode>) -> ref<Maybe<TidyNode>> :
   val ret = w_tidyGetNext(node.value)
   if ret == null :
@@ -235,4 +240,60 @@ public lostanza defn get-by-id (node:ref<TidyNode>, attrId:ref<TidyAttrId>) -> r
     return None()
   return One(TidyAttr(ret))
 
+public defn if-attr? (node:TidyNode, id:TidyAttrId, f:(TidyAttr -> True|False)) -> True|False :
+  ; Call f if there is a valid attribute of the passed type.
+  val attr? = get-by-id(node, id)
+  match(attr?) :
+    (x:None): false
+    (x:One<TidyAttr>): f(value(x))
 
+public defn with-attr? (node:TidyNode, id:TidyAttrId) -> True|False :
+  ; Returns true if this node has an attribute of the given id.
+  defn is-true (n:TidyAttr) -> True|False:
+    true
+  if-attr?(node, id, is-true)
+
+public defn is-attr? (node:TidyNode, id:TidyAttrId, cls:String ) -> True|False :
+  ; This function filters for nodes who have an attribute equal to cls
+  defn is-equal? (n:TidyAttr) -> True|False:
+    get-value(n) == cls
+  if-attr?(node, id, is-equal?)
+
+public defn is-html-id? (node:TidyNode, idName:String) -> True|False :
+  is-attr?(node, TidyAttr_ID, idName)
+
+public defn is-html-class? (node:TidyNode, cls:String) -> True|False :
+  is-attr?(node, TidyAttr_CLASS, cls)
+
+public defn has-attr? (node:TidyNode, id:TidyAttrId, query:String ) -> True|False :
+  ; For an html node attribute with multiple space-separated values:
+  ;  <p attr="asdf qwer"> ...
+  ;  This will return true if `cls` matches any of the space-separated classes
+  ;  in the `class` attribute.
+  defn has-class? (n:TidyAttr) -> True|False:
+    contains?(split(get-value(n), " "), query)
+  if-attr?(node, id, has-class?)
+
+public defn has-html-class? (node:TidyNode, cls:String) -> True|False :
+  has-attr?(node, TidyAttr_CLASS, cls)
+
+public defn contains-attr? (node:TidyNode, id:TidyAttrId, query:String) -> True|False :
+  defn contains? (n:TidyAttr) -> True|False:
+    index-of-chars(get-value(n), query) != false
+  if-attr?(node, id, contains?)
+
+public defn contains-html-id? (node:TidyNode, query:String) -> True|False :
+  contains-attr?(node, TidyAttr_ID, query)
+
+public defn contains-html-class? (node:TidyNode, query:String) -> True|False :
+  contains-attr?(node, TidyAttr_CLASS, query)
+
+public defn suffix-attr? (node:TidyNode, id:TidyAttrId, query:String) -> True|False :
+  defn at-suffix? (n:TidyAttr) -> True|False :
+    suffix?(get-value(n), query)
+  if-attr?(node, id, at-suffix?)
+
+public defn prefix-attr? (node:TidyNode, id:TidyAttrId, query:String) -> True|False :
+  defn at-prefix? (n:TidyAttr) -> True|False :
+    prefix?(get-value(n), query)
+  if-attr?(node, id, at-prefix?)

--- a/tests/DocTree.stanza
+++ b/tests/DocTree.stanza
@@ -10,6 +10,8 @@ defpackage tidy/tests/DocTree :
   import tidy/Enums/TidyNodeType
   import tidy/Enums/TidyTagId
   import tidy/Enums/TidyAttrId
+  import tidy/Enums/TidyOptionId
+
 
 
 deftest(doctree) test-basic:
@@ -225,3 +227,54 @@ deftest(doctree) test-node-attr-str:
   val attr:TidyAttr = value!(first-attr(p1))
   val aStr = to-string("%~" % [attr])
   #EXPECT(aStr == "Attr: id=asdf")
+
+deftest(doctree) test-filter-seq:
+  val doc = TidyDoc()
+  val stat = get-status(doc)
+  #EXPECT(stat == 0)
+
+  ; This quells warnings generated because the parsed HTML doesn't include
+  ;  all the necessary tags and doctypes.
+  set-bool(doc, TidyShowWarnings, false)
+
+  val msg = [
+    "<body>",
+    "<p id=\"asdf\" class=\"shark\">SomeText</p>",
+    "<p id=\"qwer\" class=\"dolphin\">OtherText</p>",
+    "<div> Non-Sense </div>",
+    "<p id=\"zxcv\" class=\"shark\">Why Sharks?</p>",
+    "<p id=\"fdsa\" class=\"shark\">Why Not Sharks?</p>",
+    "<p id=\"rewq\" class=\"dolphin\">Why Not Dolphins?</p>",
+    "<div> More Non-Sense </div>",
+    "<h1 class=\"mouse badger bear\"> Oh My <h1>",
+    "</body>",
+  ]
+  val input = string-join(msg)
+
+  val code = parse-str(doc, input)
+  #EXPECT(code == 1) ; Warning but not important.
+
+  val kids = to-tuple(get-children(get-body(doc)))
+  val pTags = to-tuple(filter({is-tag-id?(_, TidyTag_P)}, kids))
+  #EXPECT(length(pTags) == 5)
+
+  val divTags = to-tuple(filter({is-tag-id?(_, TidyTag_DIV)}, kids))
+  #EXPECT(length(divTags) == 2)
+
+  val sharks = to-tuple(filter(is-html-class?{_, "shark"}, kids))
+  #EXPECT(length(sharks) == 3)
+
+  val dolphins = to-tuple(filter(is-html-class?{_, "dolphin"}, kids))
+  #EXPECT(length(dolphins) == 2)
+
+  val asdf = to-tuple(filter(is-html-id?{_, "asdf"}, kids))
+  #EXPECT(length(asdf) == 1)
+
+  val badger = to-tuple(filter(has-html-class?{_, "badger"}, kids))
+  #EXPECT(length(badger) == 1)
+
+  val wq = to-tuple(filter(suffix-attr?{_, TidyAttr_ID, "wq"}, kids))
+  #EXPECT(length(wq) == 1)
+
+  val zx = to-tuple(filter(prefix-attr?{_, TidyAttr_ID, "zx"}, kids))
+  #EXPECT(length(zx) == 1)


### PR DESCRIPTION
Adds filter selection tools such as: 

```
val HTML = "<h1 class=\"mouse badger bear\"> Oh My <h1>"
 val badger:Tuple<TidyNode> = to-tuple(filter(has-html-class?{_, "badger"}, kids))
  #EXPECT(length(badger) == 1)
```